### PR TITLE
Add check to ensure new fields do not use Protovalidate required rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 An experimental [Buf check plugin](https://buf.build/docs/cli/buf-plugins) for [Protovalidate](https://buf.build/docs/protovalidate) that enforces:
 
-- Protovalidate annotations are not added to existing fields without Protovalidate annotations.
+- Protovalidate annotations are not added to existing fields and messages without Protovalidate annotations.
 - Existing Protovalidate annotations are never modified or removed.
+- New fields on existing messages do not get added with [`required`](https://buf.build/docs/reference/protovalidate/rules/field_rules/#required).
 
 This plugin only allows Protovalidate annotations to be added to new fields.
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 				{
 					ID:      "PROTOVALIDATE_STRICT",
 					Default: true,
-					Purpose: "Checks that Protovalidate annotations on messages and fields adhere to strict changement.",
+					Purpose: "Checks that Protovalidate annotations on messages and fields adhere to strict change management.",
 					Type:    check.RuleTypeBreaking,
 					Handler: checkutil.NewFilePairRuleHandler(handleProtovalidateStrict),
 				},


### PR DESCRIPTION
Add a check to ensure that new fields do not have `(buf.validate.field).required = true` set.